### PR TITLE
feature: add support for new Laravel 8 and above routing syntax

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
 			];
 			const TRIGGER_CHARACTERS = "\"'".split("");
 
-			context.subscriptions.push(vscode.languages.registerCompletionItemProvider(LANGUAGES, new RouteProvider, ...TRIGGER_CHARACTERS));
+			context.subscriptions.push(vscode.languages.registerCompletionItemProvider(LANGUAGES, new RouteProvider, ...TRIGGER_CHARACTERS.concat(['['])));
 			context.subscriptions.push(vscode.languages.registerCompletionItemProvider(LANGUAGES, new ViewProvider, ...TRIGGER_CHARACTERS));
 			context.subscriptions.push(vscode.languages.registerCompletionItemProvider(LANGUAGES, new ConfigProvider, ...TRIGGER_CHARACTERS));
 			context.subscriptions.push(vscode.languages.registerCompletionItemProvider(LANGUAGES, new TranslationProvider, ...TRIGGER_CHARACTERS));


### PR DESCRIPTION
We keep the current autocomplete syntax in place for when a user uses quotes while adding autocomplete for the new routing syntax when a user starts the 2nd parameter with an opening `[`.

Also added  auto-import of the selected controller. This will add the import after the last `use` value it can find. If none are located it will just add it after the opening of the `<?php` tag

Fixes https://github.com/amir9480/vscode-laravel-extra-intellisense/issues/56